### PR TITLE
fix: check tokens for escaping 

### DIFF
--- a/src/LogicStream/InternalClassNamePrefixer.php
+++ b/src/LogicStream/InternalClassNamePrefixer.php
@@ -67,12 +67,14 @@ class InternalClassNamePrefixer {
 			return $this->tokenText($token);
 		}
 
+		$prefix = $this->shouldPrefixToken($tokens, $index, $token, $imports, $state);
 		$state->updateExpectations($token);
-		if(!$this->shouldPrefixToken($tokens, $index, $token, $imports, $state)) {
-			return $this->tokenText($token);
+
+		if($prefix) {
+			return "\\" . $this->tokenText($token);
 		}
 
-		return "\\" . $this->tokenText($token);
+		return $this->tokenText($token);
 	}
 
 	/**

--- a/test/phpunit/LogicStream/LogicStreamWrapperTest.php
+++ b/test/phpunit/LogicStream/LogicStreamWrapperTest.php
@@ -97,4 +97,40 @@ class LogicStreamWrapperTest extends TestCase {
 			unlink(sys_get_temp_dir() . "/" . $tmpFile);
 		}
 	}
+
+	public function testStreamOpen_runtimeCall_UnqualifiedBuiltInClassWithoutTypeHint():void {
+		$uniqid = uniqid();
+		$tmpFile = "phpgt-routing-example-" . $uniqid;
+		$logicPath = "phpgt-test://$tmpFile";
+		$contents = <<<PHP
+		<?php
+		function example():object {
+			return new DateTime();
+		}
+		PHP;
+		$cwd = getcwd();
+		chdir(sys_get_temp_dir());
+		file_put_contents($tmpFile, $contents);
+
+		try {
+			$sut = new LogicStreamWrapper();
+			$sut->stream_open($logicPath);
+			$wrappedContents = $sut->stream_read(4096);
+
+			eval(substr($wrappedContents, strlen("<?php")));
+			$namespace = preg_match('/namespace\\s+([^;]+);/', $wrappedContents, $matches)
+				? $matches[1]
+				: "";
+			$callable = $namespace . "\\example";
+
+			self::assertStringContainsString("new \\DateTime()", $wrappedContents);
+			self::assertInstanceOf(DateTime::class, $callable());
+		}
+		finally {
+			if($cwd !== false) {
+				chdir($cwd);
+			}
+			unlink(sys_get_temp_dir() . "/" . $tmpFile);
+		}
+	}
 }


### PR DESCRIPTION
closes #114

Fixed `InternalClassNamePrefixer` so it checks whether the current token should be prefixed before updating the parser state for that token.

Previously, seeing new set the "expect class name" state, but the following class-name token could clear that state before prefixing was evaluated. As a result, `new ZipArchive()` was left unqualified while `ZipArchive::CREATE` was correctly rewritten.

Also added a regression test covering an unqualified internal class used in a new expression without relying on a matching return type hint.